### PR TITLE
Refine place definitions and update map styling

### DIFF
--- a/SafePathZC/frontend/src/components/MapView.tsx
+++ b/SafePathZC/frontend/src/components/MapView.tsx
@@ -9830,10 +9830,13 @@ export const MapView = ({ onModalOpen }: MapViewProps) => {
         markerEntry.addTo(map);
       }
       const style = PLACE_CATEGORY_STYLES[place.category];
+      const displayLabel = place.categoryLabel ?? style.label;
       const lines = [
         `<div class="place-popup-card">`,
         `<div class="place-popup-name">${place.name}</div>`,
-        style.label ? `<div class="place-popup-category">${style.label}</div>` : "",
+        displayLabel
+          ? `<div class="place-popup-category">${displayLabel}</div>`
+          : "",
         place.description ? `<div class="place-popup-description">${place.description}</div>` : "",
         place.address ? `<div class="place-popup-address">${place.address}</div>` : "",
         `<button class="place-popup-action" id="place-directions-${place.id}">Directions from my location</button>`,


### PR DESCRIPTION
## Summary
- replace the bespoke place model with a shared `PlaceDefinition`, export the fallback dataset, and expose category styling for map consumers
- normalize fallback place entries to the new categories and merge dynamic Overpass results when available
- update the map popup to prefer per-place labels when present while using the shared styling map

## Testing
- npm run lint *(fails: existing lint violations throughout the project)*

------
https://chatgpt.com/codex/tasks/task_e_68db79fbcdb883229cf23368f8a6580a