### PR TITLE
Refresh POI markers with dynamic Overpass data

### DIFF
--- a/SafePathZC/frontend/src/App.css
+++ b/SafePathZC/frontend/src/App.css
@@ -300,24 +300,29 @@
 }
 
 .map-place-icon-inner {
-  width: 28px;
-  height: 28px;
-  border-radius: 14px;
-  background: #111827;
-  color: #f9fafb;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 16px;
-  border: 2px solid var(--marker-color, #2563eb);
-  box-shadow: 0 6px 12px rgba(17, 24, 39, 0.25);
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: #ffffff;
+  position: relative;
+  border: 3px solid var(--marker-color, #2563eb);
+  box-shadow: 0 8px 16px rgba(15, 23, 42, 0.2);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.map-place-icon-inner::after {
+  content: "";
+  position: absolute;
+  inset: 4px;
+  border-radius: 50%;
+  background: var(--marker-color, #2563eb);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.6);
 }
 
 .map-place-icon-active .map-place-icon-inner,
 .map-place-icon-inner:hover {
-  transform: translateY(-2px) scale(1.05);
-  box-shadow: 0 10px 22px rgba(17, 24, 39, 0.35);
+  transform: scale(1.25);
+  box-shadow: 0 14px 28px rgba(15, 23, 42, 0.3);
 }
 
 .place-info-popup .leaflet-popup-content-wrapper {


### PR DESCRIPTION
## Summary
- replace emoji-based POI markers with circular icons that mirror Google Maps styling and scale appropriately
- fetch points of interest from the Overpass API, keep a runtime cache, and refresh markers when new data loads
- update map visibility logic to honour higher zoom thresholds so POIs appear alongside clear street labels

## Testing
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68de904e9170832292079601ff90ae18