### PR TITLE
Color-code POI markers by category

### DIFF
--- a/SafePathZC/frontend/src/App.css
+++ b/SafePathZC/frontend/src/App.css
@@ -300,24 +300,30 @@
 }
 
 .map-place-icon-inner {
-  width: 28px;
-  height: 28px;
-  border-radius: 14px;
-  background: #111827;
-  color: #f9fafb;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background: var(--marker-color, #2563eb);
+  border: 3px solid #ffffff;
+  box-shadow: 0 12px 26px rgba(15, 23, 42, 0.24);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 16px;
-  border: 2px solid var(--marker-color, #2563eb);
-  box-shadow: 0 6px 12px rgba(17, 24, 39, 0.25);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  color: #ffffff;
+  position: relative;
 }
 
 .map-place-icon-active .map-place-icon-inner,
 .map-place-icon-inner:hover {
-  transform: translateY(-2px) scale(1.05);
-  box-shadow: 0 10px 22px rgba(17, 24, 39, 0.35);
+  transform: scale(1.25);
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.35);
+}
+
+.map-place-icon-glyph {
+  font-size: 0.9rem;
+  line-height: 1;
+  text-shadow: 0 2px 4px rgba(15, 23, 42, 0.28);
 }
 
 .place-info-popup .leaflet-popup-content-wrapper {
@@ -337,6 +343,21 @@
   min-width: 220px;
   max-width: 280px;
   color: #0f172a;
+}
+
+.place-popup-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.place-popup-title-block {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .place-popup-card--empty {
@@ -374,25 +395,53 @@
   font-weight: 600;
   font-size: 15px;
   color: #0f172a;
+  line-height: 1.25;
 }
 
 .place-popup-category {
-  font-size: 12px;
-  font-weight: 500;
-  color: rgba(15, 23, 42, 0.65);
+  margin-top: 6px;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 13px;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.place-popup-category-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  background: var(--category-color, rgba(37, 99, 235, 0.9));
+  color: #ffffff;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.22);
+}
+
+.place-popup-category-icon .fa-solid {
+  font-size: 0.95rem;
 }
 
 .place-popup-description {
   font-size: 13px;
   color: rgba(15, 23, 42, 0.78);
   line-height: 1.35;
-  margin-bottom: 8px;
+  margin-top: 10px;
 }
 
 .place-popup-address {
   font-size: 12px;
   color: rgba(15, 23, 42, 0.6);
-  margin-bottom: 10px;
+  line-height: 1.4;
+  margin: 0;
+}
+
+.place-popup-coordinates {
+  font-size: 12px;
+  color: rgba(15, 23, 42, 0.55);
+  margin-top: 6px;
 }
 
 .place-popup-tags {
@@ -414,21 +463,42 @@
 }
 
 .place-popup-action {
-  width: 100%;
   border: none;
-  border-radius: 10px;
-  background: #2563eb;
-  color: #f8fafc;
-  font-weight: 600;
-  font-size: 13px;
-  padding: 10px 12px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  color: #ffffff;
+  width: 44px;
+  height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.35);
   cursor: pointer;
-  transition: background 0.2s ease, transform 0.2s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  flex-shrink: 0;
 }
 
 .place-popup-action:hover {
-  background: #1d4ed8;
-  transform: translateY(-1px);
+  transform: translateY(-1px) scale(1.03);
+  box-shadow: 0 14px 28px rgba(37, 99, 235, 0.45);
+}
+
+.place-popup-action:active {
+  transform: translateY(0) scale(0.97);
+}
+
+.place-popup-action:focus {
+  outline: none;
+}
+
+.place-popup-action:focus-visible {
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.35);
+}
+
+.place-popup-action-icon {
+  width: 18px;
+  height: 18px;
+  display: block;
 }
 
 .place-popup-small {


### PR DESCRIPTION
## Summary
- assign each supported POI category a Font Awesome glyph and Google Maps-inspired color swatch
- render the category icon in both the in-map marker badge and popup header chips with refreshed styling
- keep marker popups accessible by sanitizing markup and mirroring the icon palette in the popup layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de904e9170832292079601ff90ae18