### PR TITLE
Improve OSRM fallback alignment

### DIFF
--- a/SafePathZC/backend/services/local_routing.py
+++ b/SafePathZC/backend/services/local_routing.py
@@ -578,7 +578,7 @@ def calculate_local_route(start_lat: float, start_lng: float,
     
     if route:
         route_info = service.get_route_info(route, mode)
-        
+
         return {
             "success": True,
             "route": [{"lat": coord.lat, "lng": coord.lng} for coord in route],
@@ -588,5 +588,5 @@ def calculate_local_route(start_lat: float, start_lng: float,
             "terrain_summary": route_info["terrain_summary"],
             "source": "local_geojson_terrain"
         }
-    
+
     return None


### PR DESCRIPTION
## Summary
- align fallback OSRM routes with the requested start and end coordinates so polylines reach point B
- add metadata about geometry adjustments and log fallback corrections for OSRM routes
- tidy the local routing helper return path to keep formatting consistent

## Testing
- python -m compileall services/local_routing.py main.py

------
https://chatgpt.com/codex/tasks/task_e_68e1d978411c832290cb21a8c233baf3